### PR TITLE
fix: preserve line structure in translation and improve error recovery

### DIFF
--- a/src/adapters/translate/gemini.rs
+++ b/src/adapters/translate/gemini.rs
@@ -91,15 +91,26 @@ impl Translator for GeminiTranslator {
         if self.api_key.trim().is_empty() {
             bail!("Gemini API key is empty (open Settings and set it)");
         }
+        let line_count = text.lines().count();
+        let line_instruction = if line_count > 1 {
+            format!(
+                " The source has exactly {line_count} lines. \
+                 Output exactly {line_count} translated lines in the same order, \
+                 one per line, with no extra blank lines."
+            )
+        } else {
+            String::new()
+        };
+
         let prompt = if let Some(src) = source {
             format!(
-                "Translate from {} to {}. Output ONLY the translation text.\n\n{}",
-                src.0, target.0, text
+                "Translate from {} to {}.{} Output ONLY the translated text, no explanations.\n\n{}",
+                src.0, target.0, line_instruction, text
             )
         } else {
             format!(
-                "Translate to {}. Auto-detect the source language. Output ONLY the translation text.\n\n{}",
-                target.0, text
+                "Translate to {}. Auto-detect the source language.{} Output ONLY the translated text, no explanations.\n\n{}",
+                target.0, line_instruction, text
             )
         };
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -840,9 +840,40 @@ impl App {
                     self.slot_busy[slot_idx] = false;
                     self.slot_processing[slot_idx] = false;
                     let now = Self::now_ms();
-                    let mut model = self.model.lock();
-                    model.slots[slot_idx].next_tick_at_ms = now.saturating_add(10_000);
-                    self.last_error = Some(format!("Region {}: {err}", slot_idx + 1));
+
+                    // Parse Gemini retryDelay (e.g. "27s") from 429 responses.
+                    // Fall back to 30 s if not found.
+                    let retry_ms: u64 = {
+                        let re_delay = err
+                            .split('"')
+                            .skip_while(|s| *s != "retryDelay")
+                            .nth(2) // value after key + colon token
+                            .and_then(|s| s.trim_matches(|c: char| !c.is_ascii_digit() && c != '.').parse::<f64>().ok())
+                            .unwrap_or(30.0);
+                        (re_delay * 1000.0) as u64
+                    };
+
+                    {
+                        let mut model = self.model.lock();
+                        model.slots[slot_idx].next_tick_at_ms = now.saturating_add(retry_ms.max(10_000));
+                    }
+
+                    // Reset frame hash so the retry tick actually re-runs OCR+translate
+                    // instead of hitting the Unchanged fast-path.
+                    if slot_idx < self.last_frame_hash.len() {
+                        self.last_frame_hash[slot_idx] = 0;
+                    }
+
+                    // Show a friendly error message instead of raw JSON.
+                    let friendly = if err.contains("429") || err.contains("RESOURCE_EXHAUSTED") {
+                        let secs = retry_ms / 1000;
+                        format!("Region {}: Gemini quota exceeded — retrying in {secs}s", slot_idx + 1)
+                    } else {
+                        // Strip raw JSON body, keep just the first meaningful line
+                        let first_line = err.lines().next().unwrap_or(&err).trim().to_string();
+                        format!("Region {}: {first_line}", slot_idx + 1)
+                    };
+                    self.last_error = Some(friendly);
                 }
             }
         }


### PR DESCRIPTION
Translation prompt (gemini.rs):
- Add line count instruction when source has multiple lines 'Output exactly N translated lines in the same order, one per line' This ensures last_trans_lines matches last_ocr_lines for positional overlay

Error handler (app.rs):
- Parse retryDelay from Gemini 429 response body (e.g. '27s') and use it as the actual retry backoff instead of hardcoded 10 s
- Reset last_frame_hash to 0 on error so the next tick forces a re-run of OCR+translate (previously hash == prev_hash caused the Unchanged fast-path to skip all retries, making it translate once only)
- Show clean human-readable error instead of raw JSON dump: '429 / RESOURCE_EXHAUSTED -> Region 1: Gemini quota exceeded - retrying in 27s'