### PR TITLE
fix(overlay): eliminate self-referencing loop and fix line alignment

### DIFF
--- a/src/adapters/ocr/windows_ocr.rs
+++ b/src/adapters/ocr/windows_ocr.rs
@@ -72,7 +72,10 @@ impl WindowsOcr {
         for idx in 0..count {
             let line = lines.GetAt(idx)?;
             let text = line.Text()?.to_string();
-            if text.trim().is_empty() {
+            // Skip noise: empty lines, single chars, or pure punctuation/whitespace.
+            // Manga scans often produce many 1-2 char OCR fragments from artwork.
+            let trimmed = text.trim();
+            if trimmed.len() < 3 || trimmed.chars().all(|c| !c.is_alphanumeric()) {
                 continue;
             }
 

--- a/src/adapters/translate/gemini.rs
+++ b/src/adapters/translate/gemini.rs
@@ -91,26 +91,44 @@ impl Translator for GeminiTranslator {
         if self.api_key.trim().is_empty() {
             bail!("Gemini API key is empty (open Settings and set it)");
         }
-        let line_count = text.lines().count();
-        let line_instruction = if line_count > 1 {
-            format!(
-                " The source has exactly {line_count} lines. \
-                 Output exactly {line_count} translated lines in the same order, \
-                 one per line, with no extra blank lines."
-            )
+
+        // ── Numbered-line protocol ──────────────────────────────────────────
+        // When the source has multiple lines (one per OCR text-block), we prefix
+        // each line with its 1-based index and ask Gemini to return the same
+        // numbering. This guarantees that the translated line at index N maps to
+        // OCR line N even if Gemini skips or merges some lines.
+        let source_lines: Vec<&str> = text.lines().collect();
+        let (prompt_body, multi_line) = if source_lines.len() > 1 {
+            let numbered = source_lines
+                .iter()
+                .enumerate()
+                .map(|(i, l)| format!("{}. {}", i + 1, l))
+                .collect::<Vec<_>>()
+                .join("\n");
+            (numbered, true)
         } else {
-            String::new()
+            (text.to_string(), false)
+        };
+
+        let line_instruction = if multi_line {
+            " The source is a numbered list of text blocks, one per line. \
+             Return ONLY the translations as a numbered list in the same format \
+             (e.g. '1. translation'). Keep the same numbering. \
+             Do not add explanations or extra lines."
+                .to_string()
+        } else {
+            " Output ONLY the translated text, no explanations.".to_string()
         };
 
         let prompt = if let Some(src) = source {
             format!(
-                "Translate from {} to {}.{} Output ONLY the translated text, no explanations.\n\n{}",
-                src.0, target.0, line_instruction, text
+                "Translate from {} to {}.{}\n\n{}",
+                src.0, target.0, line_instruction, prompt_body
             )
         } else {
             format!(
-                "Translate to {}. Auto-detect the source language.{} Output ONLY the translated text, no explanations.\n\n{}",
-                target.0, line_instruction, text
+                "Translate to {}. Auto-detect the source language.{}\n\n{}",
+                target.0, line_instruction, prompt_body
             )
         };
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -718,7 +718,14 @@ impl App {
                         use windows::Win32::Foundation::COLORREF;
                         use windows::Win32::UI::WindowsAndMessaging::{
                             FindWindowW, SetLayeredWindowAttributes, LWA_COLORKEY,
+                            SetWindowDisplayAffinity, WINDOW_DISPLAY_AFFINITY,
                         };
+                        // WDA_EXCLUDEFROMCAPTURE = 0x11: window is visible to the user
+                        // but excluded from screen capture / screenshots APIs. This breaks
+                        // the self-referencing loop where the overlay's own translated text
+                        // was being captured, OCR-read, and re-translated into garbled output.
+                        const WDA_EXCLUDEFROMCAPTURE: WINDOW_DISPLAY_AFFINITY =
+                            WINDOW_DISPLAY_AFFINITY(0x00000011);
                         let title_w: Vec<u16> = format!("Frame Overlay {}\0", slot_id + 1)
                             .encode_utf16()
                             .collect();
@@ -736,6 +743,9 @@ impl App {
                                     0,
                                     LWA_COLORKEY,
                                 );
+                                // Exclude overlay from screen capture so its translated
+                                // text is never captured and fed back into OCR.
+                                let _ = SetWindowDisplayAffinity(hwnd, WDA_EXCLUDEFROMCAPTURE);
                                 hwnd_cache.store(raw, std::sync::atomic::Ordering::Relaxed);
                             }
                         }
@@ -755,6 +765,48 @@ impl App {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
             .as_millis() as u64
+    }
+
+    /// Parse a numbered translation response back into a Vec aligned to
+    /// the original OCR lines.
+    ///
+    /// Gemini returns lines like:
+    ///   "1. สวัสดี"
+    ///   "2. เป็นอย่างไร"
+    ///   "3. ฉันสบายดี"
+    ///
+    /// We extract the number and put the text at `result[number - 1]`.
+    /// Any missing numbers get an empty string so positions stay aligned.
+    /// If the response has no numbers at all (single-line or model ignored
+    /// the instruction), fall back to plain line-split.
+    fn parse_numbered_lines(raw: &str, ocr_count: usize) -> Vec<String> {
+        // Detect whether the response uses the numbered format.
+        let has_numbers = raw.lines().any(|l| {
+            let t = l.trim();
+            t.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
+                && t.contains('.')
+        });
+
+        if !has_numbers || ocr_count == 0 {
+            // Plain split fallback
+            return raw.lines().map(|s| s.trim().to_string()).collect();
+        }
+
+        let mut result: Vec<String> = vec![String::new(); ocr_count];
+        for line in raw.lines() {
+            let trimmed = line.trim();
+            // Match "N. text" or "N) text"
+            if let Some(dot) = trimmed.find(|c: char| c == '.' || c == ')') {
+                let idx_str = &trimmed[..dot];
+                if let Ok(idx) = idx_str.trim().parse::<usize>() {
+                    if idx >= 1 && idx <= ocr_count {
+                        let content = trimmed[dot + 1..].trim().to_string();
+                        result[idx - 1] = content;
+                    }
+                }
+            }
+        }
+        result
     }
 
     fn tick_background(&mut self) {
@@ -784,11 +836,11 @@ impl App {
                     if content_changed {
                         slot.last_ocr_text = ocr_text;
                         if !translated.trim().is_empty() {
-                            // Split translation into per-line strings to match OCR positions
-                            slot.last_trans_lines = translated
-                                .lines()
-                                .map(|s| s.to_string())
-                                .collect();
+                            let line_count = ocr_lines.len();
+                            // Parse numbered response ("1. foo\n2. bar") back to
+                            // a Vec aligned to OCR line indices.
+                            slot.last_trans_lines =
+                                Self::parse_numbered_lines(&translated, line_count);
                             slot.last_ocr_lines = ocr_lines;
                             slot.last_translation = translated;
                             slot.pending_text.clear();


### PR DESCRIPTION
Self-referencing capture loop (app.rs):
- Add SetWindowDisplayAffinity(WDA_EXCLUDEFROMCAPTURE=0x11) alongside SetLayeredWindowAttributes when the overlay HWND is (re-)applied
- Overlay window is now invisible to the screenshots crate so the translated Thai text is never captured, OCR-read, and re-translated into garbled output (the root cause of the re-translate distortion)

OCR noise filter (windows_ocr.rs):
- Skip lines where len < 3 or all chars are non-alphanumeric (manga artwork produces many 1-2 char fragments that pollute the translation and inflate the line count)

Numbered-line translation protocol (gemini.rs + app.rs):
- Prefix each OCR line with its 1-based index before sending to Gemini: '1. Hello\n2. how are you\n3. I am fine'
- Gemini returns '1. สวัสดี\n2. เป็นอย่างไรบ้าง\n3. ฉันสบายดี'
- New parse_numbered_lines() helper in App maps each numbered result back to result[N-1], keeping positions perfectly aligned even when Gemini skips or merges lines (missing entries become empty strings)
- Falls back to plain line-split if Gemini ignores the numbering