### PR TITLE
feat: increase translation token limits for long-form text

### DIFF
--- a/src/adapters/translate/gemini.rs
+++ b/src/adapters/translate/gemini.rs
@@ -139,7 +139,7 @@ impl Translator for GeminiTranslator {
             generation_config: Some(GenerationConfig {
                 temperature: Some(0.2),
                 top_p: Some(0.95),
-                max_output_tokens: Some(512),
+                max_output_tokens: Some(4096),
                 // Disable reasoning tokens — translation is deterministic.
                 // Ignored by models that don't support it; saves tokens on 2.5-flash.
                 thinking_config: Some(ThinkingConfig { thinking_budget: 0 }),

--- a/src/adapters/translate/groq.rs
+++ b/src/adapters/translate/groq.rs
@@ -108,7 +108,7 @@ impl Translator for GroqTranslator {
                 },
             ],
             temperature: 0.2,
-            max_tokens: 512,
+            max_tokens: 4096,
         };
 
         let resp = self.client

--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -104,7 +104,10 @@ impl Translator for OllamaTranslator {
                 },
             ],
             stream: false,
-            options: Some(OllamaOptions { temperature: 0.2 }),
+            options: Some(OllamaOptions {
+                temperature: 0.2,
+                num_predict: 4096,
+            }),
         };
 
         let endpoint = format!("{}/api/chat", self.url);
@@ -143,6 +146,7 @@ struct OllamaMessage {
 #[derive(Serialize)]
 struct OllamaOptions {
     temperature: f32,
+    num_predict: u32,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
- Increase Groq max_tokens to 4096.
- Increase Gemini max_output_tokens to 4096.
- Add and set Ollama um_predict to 4096.
- This ensures full translations for large text blocks, such as novel pages or long articles, preventing the AI from cutting off responses prematurely.