### PR TITLE
feat: enable text wrapping for all overlay types

### DIFF
--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -33,7 +33,6 @@ impl Translator for OllamaTranslator {
         target: &LanguageTag,
     ) -> Result<String> {
         let source_lines: Vec<&str> = text.lines().collect();
-        let multi_line = source_lines.len() > 1;
 
         // Convert language codes to full names for better AI understanding
         let target_name = match target.0.as_str() {
@@ -52,38 +51,73 @@ impl Translator for OllamaTranslator {
             _ => &target.0,
         };
 
-        let system_prompt = if multi_line {
-            format!(
-                "Translate each line into {}. \
-                 Return EXACTLY {} lines, one translation per line. \
-                 Do NOT add numbers, bullet points, or any extra text. \
-                 Do NOT merge or skip lines. Output ONLY the translations.",
-                target_name, source_lines.len()
-            )
+        let src_name = source.map(|s| match s.0.as_str() {
+            "th" => "Thai",
+            "en" => "English",
+            "ja" => "Japanese",
+            "zh-Hans" => "Chinese Simplified",
+            "zh-Hant" => "Chinese Traditional",
+            "ko" => "Korean",
+            _ => &s.0,
+        });
+
+        // For multi-line: translate each line individually to guarantee alignment.
+        // Local models are unlimited, so multiple calls are fine.
+        if source_lines.len() > 1 {
+            let mut results = Vec::with_capacity(source_lines.len());
+            for (i, line) in source_lines.iter().enumerate() {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    results.push(String::new());
+                    continue;
+                }
+
+                // Include surrounding lines as context (but only translate the target line)
+                let context_hint = if source_lines.len() > 1 {
+                    let prev = if i > 0 { source_lines[i - 1] } else { "" };
+                    let next = if i + 1 < source_lines.len() { source_lines[i + 1] } else { "" };
+                    format!(
+                        " Context — previous line: \"{}\", next line: \"{}\".",
+                        prev, next
+                    )
+                } else {
+                    String::new()
+                };
+
+                let system = format!(
+                    "Translate into {}. Output ONLY the translation, nothing else. No numbers, no bullet points, no explanations.{}",
+                    target_name, context_hint
+                );
+
+                let user = if let Some(sn) = src_name {
+                    format!("{} → {}: {}", sn, target_name, trimmed)
+                } else {
+                    trimmed.to_string()
+                };
+
+                let translated_line = self.call_ollama(&system, &user)?;
+                results.push(translated_line);
+            }
+            return Ok(results.join("\n"));
+        }
+
+        // Single line — simple translation
+        let system = format!(
+            "Translate into {}. Output ONLY the translation, nothing else.",
+            target_name
+        );
+        let user = if let Some(sn) = src_name {
+            format!("{} → {}: {}", sn, target_name, text.trim())
         } else {
-            format!(
-                "Translate into {}. Output ONLY the translation, nothing else.",
-                target_name
-            )
+            text.trim().to_string()
         };
 
-        let prompt_body = text.to_string();
+        self.call_ollama(&system, &user)
+    }
+}
 
-        let user_prompt = if let Some(src) = source {
-            let src_name = match src.0.as_str() {
-                "th" => "Thai",
-                "en" => "English",
-                "ja" => "Japanese",
-                "zh-Hans" => "Chinese Simplified",
-                "zh-Hant" => "Chinese Traditional",
-                "ko" => "Korean",
-                _ => &src.0,
-            };
-            format!("Translate from {} to {}:\n\n{}", src_name, target_name, prompt_body)
-        } else {
-            format!("Translate to {}:\n\n{}", target_name, prompt_body)
-        };
-
+impl OllamaTranslator {
+    fn call_ollama(&self, system_prompt: &str, user_prompt: &str) -> Result<String> {
         let req = OllamaChatRequest {
             model: self.model.clone(),
             messages: vec![
@@ -117,7 +151,10 @@ impl Translator for OllamaTranslator {
         }
 
         let data: OllamaChatResponse = resp.json().context("parse ollama response")?;
-        Ok(data.message.content.trim().to_string())
+        // Take only the first non-empty line to prevent multi-line leakage
+        let content = data.message.content.trim();
+        let first_line = content.lines().next().unwrap_or(content).trim();
+        Ok(first_line.to_string())
     }
 }
 

--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -14,7 +14,7 @@ pub struct OllamaTranslator {
 impl OllamaTranslator {
     pub fn new(url: String, model: String) -> Result<Self> {
         let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(60)) // Local models can be slow
+            .timeout(std::time::Duration::from_secs(300)) // Local models can be very slow on CPU
             .build()
             .context("build http client")?;
         Ok(Self {

--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -106,7 +106,7 @@ impl OllamaTranslator {
             stream: false,
             options: Some(OllamaOptions {
                 temperature: 0.2,
-                num_predict: 4096,
+                num_predict: -1, // unlimited — let the model finish naturally
             }),
         };
 
@@ -146,7 +146,7 @@ struct OllamaMessage {
 #[derive(Serialize)]
 struct OllamaOptions {
     temperature: f32,
-    num_predict: u32,
+    num_predict: i32,
 }
 
 #[derive(Deserialize)]

--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -33,17 +33,7 @@ impl Translator for OllamaTranslator {
         target: &LanguageTag,
     ) -> Result<String> {
         let source_lines: Vec<&str> = text.lines().collect();
-        let (prompt_body, multi_line) = if source_lines.len() > 1 {
-            let numbered = source_lines
-                .iter()
-                .enumerate()
-                .map(|(i, l)| format!("{}. {}", i + 1, l))
-                .collect::<Vec<_>>()
-                .join("\n");
-            (numbered, true)
-        } else {
-            (text.to_string(), false)
-        };
+        let multi_line = source_lines.len() > 1;
 
         // Convert language codes to full names for better AI understanding
         let target_name = match target.0.as_str() {
@@ -64,19 +54,20 @@ impl Translator for OllamaTranslator {
 
         let system_prompt = if multi_line {
             format!(
-                "You are a professional translator. CRITICAL: Translate each numbered line into {}. \
-                 You MUST return EXACTLY the same number of lines as provided. \
-                 Keep the same numbering (N. <translation>). Do NOT skip or merge lines. \
-                 Output ONLY the translated numbered list, no extra text.",
-                target_name
+                "Translate each line into {}. \
+                 Return EXACTLY {} lines, one translation per line. \
+                 Do NOT add numbers, bullet points, or any extra text. \
+                 Do NOT merge or skip lines. Output ONLY the translations.",
+                target_name, source_lines.len()
             )
         } else {
             format!(
-                "You are a professional translator. Translate this text into {}. \
-                 Output ONLY the translated text, no explanations.",
+                "Translate into {}. Output ONLY the translation, nothing else.",
                 target_name
             )
         };
+
+        let prompt_body = text.to_string();
 
         let user_prompt = if let Some(src) = source {
             let src_name = match src.0.as_str() {

--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -61,55 +61,28 @@ impl Translator for OllamaTranslator {
             _ => &s.0,
         });
 
-        // For multi-line: translate each line individually to guarantee alignment.
-        // Local models are unlimited, so multiple calls are fine.
-        if source_lines.len() > 1 {
-            let mut results = Vec::with_capacity(source_lines.len());
-            for (i, line) in source_lines.iter().enumerate() {
-                let trimmed = line.trim();
-                if trimmed.is_empty() {
-                    results.push(String::new());
-                    continue;
-                }
-
-                // Include surrounding lines as context (but only translate the target line)
-                let context_hint = if source_lines.len() > 1 {
-                    let prev = if i > 0 { source_lines[i - 1] } else { "" };
-                    let next = if i + 1 < source_lines.len() { source_lines[i + 1] } else { "" };
-                    format!(
-                        " Context — previous line: \"{}\", next line: \"{}\".",
-                        prev, next
-                    )
-                } else {
-                    String::new()
-                };
-
-                let system = format!(
-                    "Translate into {}. Output ONLY the translation, nothing else. No numbers, no bullet points, no explanations.{}",
-                    target_name, context_hint
-                );
-
-                let user = if let Some(sn) = src_name {
-                    format!("{} → {}: {}", sn, target_name, trimmed)
-                } else {
-                    trimmed.to_string()
-                };
-
-                let translated_line = self.call_ollama(&system, &user)?;
-                results.push(translated_line);
-            }
-            return Ok(results.join("\n"));
-        }
-
-        // Single line — simple translation
-        let system = format!(
-            "Translate into {}. Output ONLY the translation, nothing else.",
-            target_name
-        );
-        let user = if let Some(sn) = src_name {
-            format!("{} → {}: {}", sn, target_name, text.trim())
+        let system = if source_lines.len() > 1 {
+            format!(
+                "Translate each line into {}. \
+                 Return EXACTLY {} lines of translation. \
+                 Each input line must have exactly one output line. \
+                 Do NOT add numbers, bullets, or explanations. \
+                 Do NOT merge or skip lines. \
+                 Keep blank lines as blank lines. \
+                 Output ONLY the translated lines, one per line.",
+                target_name, source_lines.len()
+            )
         } else {
-            text.trim().to_string()
+            format!(
+                "Translate into {}. Output ONLY the translation, nothing else.",
+                target_name
+            )
+        };
+
+        let user = if let Some(sn) = src_name {
+            format!("Translate from {} to {}:\n\n{}", sn, target_name, text)
+        } else {
+            format!("Translate to {}:\n\n{}", target_name, text)
         };
 
         self.call_ollama(&system, &user)
@@ -151,10 +124,7 @@ impl OllamaTranslator {
         }
 
         let data: OllamaChatResponse = resp.json().context("parse ollama response")?;
-        // Take only the first non-empty line to prevent multi-line leakage
-        let content = data.message.content.trim();
-        let first_line = content.lines().next().unwrap_or(content).trim();
-        Ok(first_line.to_string())
+        Ok(data.message.content.trim().to_string())
     }
 }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -914,6 +914,7 @@ impl App {
         /// "1. ", "1) ", "1: ", "- ", "* ", "• ", "n. ", etc.
         fn strip_prefix(s: &str) -> &str {
             let t = s.trim();
+            if t.is_empty() { return t; }
             // Try stripping leading digits + punctuation (e.g. "1. ", "12) ", "3: ")
             let after_digits = t.trim_start_matches(|c: char| c.is_ascii_digit());
             if after_digits.len() < t.len() {
@@ -938,26 +939,35 @@ impl App {
             return vec![];
         }
 
-        // Collect non-empty lines and strip prefixes
-        let cleaned: Vec<String> = raw
+        // Preserve ALL lines (including empty ones) to maintain index alignment
+        // with OCR line positions. DO NOT filter empty lines!
+        let all_lines: Vec<String> = raw
             .lines()
             .map(|l| strip_prefix(l).to_string())
-            .filter(|s| !s.is_empty())
             .collect();
 
-        if cleaned.len() == ocr_count {
-            return cleaned;
+        // If line count matches exactly, return as-is (perfect alignment)
+        if all_lines.len() == ocr_count {
+            return all_lines;
         }
 
-        // Line count mismatch — pad or truncate
-        let mut result = Vec::with_capacity(ocr_count);
-        for i in 0..ocr_count {
-            if i < cleaned.len() {
-                result.push(cleaned[i].clone());
-            } else {
-                result.push(String::new());
+        // If AI returned more lines than OCR (e.g. added explanations),
+        // try removing truly empty lines to see if it matches
+        if all_lines.len() > ocr_count {
+            let non_empty: Vec<String> = all_lines.iter()
+                .filter(|s| !s.is_empty())
+                .cloned()
+                .collect();
+            if non_empty.len() == ocr_count {
+                return non_empty;
             }
+            // Still doesn't match — truncate to ocr_count
+            return all_lines.into_iter().take(ocr_count).collect();
         }
+
+        // AI returned fewer lines — pad with empty strings
+        let mut result = all_lines;
+        result.resize(ocr_count, String::new());
         result
     }
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1402,6 +1402,10 @@ impl App {
 
                     // 5. Hit Translation API for TEXT-ONLY translation.
                     if let Some(t) = &translator {
+                        let _ = tx.send(BgResult::StatusUpdate { 
+                            slot_idx: i, 
+                            status: "Translating (waiting for AI)...".to_string() 
+                        });
                         let translated =
                             t.translate(&ocr_text, source_lang.as_ref(), &target_lang)?;
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1606,19 +1606,30 @@ impl App {
 
                             // ── Recommended models dropdown ──
                             let ollama_models: Vec<(&str, &str, &str)> = vec![
-                                ("qwen2.5:7b",       "Qwen 2.5 7B",       "🌟 Best for Asian languages (8GB VRAM)"),
-                                ("qwen2.5:14b",      "Qwen 2.5 14B",      "🌟 Higher quality Asian translation (12GB VRAM)"),
-                                ("qwen2.5:32b",      "Qwen 2.5 32B",      "🏆 Premium quality (24GB VRAM)"),
-                                ("qwen2.5:72b",      "Qwen 2.5 72B",      "🏆 Near GPT-4 quality (48GB+ VRAM)"),
-                                ("qwen3:8b",         "Qwen 3 8B",         "🆕 Latest Qwen generation (8GB VRAM)"),
-                                ("qwen3:14b",        "Qwen 3 14B",        "🆕 Latest Qwen generation (12GB VRAM)"),
-                                ("qwen3:32b",        "Qwen 3 32B",        "🆕 Latest Qwen generation (24GB VRAM)"),
-                                ("gemma2:9b",        "Gemma 2 9B",        "Google's efficient model (8GB VRAM)"),
-                                ("gemma2:27b",       "Gemma 2 27B",       "Google's premium model (20GB VRAM)"),
-                                ("aya-expanse:8b",   "Aya Expanse 8B",    "🌐 Multilingual specialist (8GB VRAM)"),
-                                ("aya-expanse:32b",  "Aya Expanse 32B",   "🌐 Best multilingual quality (24GB VRAM)"),
-                                ("llama3.1:8b",      "Llama 3.1 8B",      "Meta's versatile model (8GB VRAM)"),
-                                ("llama3.3:70b",     "Llama 3.3 70B",     "Meta's flagship model (48GB+ VRAM)"),
+                                // ── Lightweight (CPU / Low VRAM) ──
+                                ("qwen2.5:0.5b",     "Qwen 2.5 0.5B",     "⚡ Ultra-light, CPU OK (~1GB)"),
+                                ("qwen2.5:1.5b",     "Qwen 2.5 1.5B",     "⚡ Very light, CPU OK (~2GB)"),
+                                ("qwen2.5:3b",       "Qwen 2.5 3B",       "⚡ Light & capable (~3GB)"),
+                                ("llama3.2:1b",      "Llama 3.2 1B",      "⚡ Meta ultra-light (~2GB)"),
+                                ("llama3.2:3b",      "Llama 3.2 3B",      "⚡ Meta light (~3GB)"),
+                                ("gemma2:2b",        "Gemma 2 2B",        "⚡ Google ultra-light (~2GB)"),
+                                ("phi3:mini",        "Phi-3 Mini 3.8B",   "⚡ Microsoft light (~3GB)"),
+                                // ── Medium (8GB VRAM) ──
+                                ("qwen2.5:7b",       "Qwen 2.5 7B",       "🌟 Best for Asian languages (8GB)"),
+                                ("qwen3:8b",         "Qwen 3 8B",         "🆕 Latest Qwen (8GB)"),
+                                ("gemma2:9b",        "Gemma 2 9B",        "Google efficient (8GB)"),
+                                ("aya-expanse:8b",   "Aya Expanse 8B",    "🌐 Multilingual specialist (8GB)"),
+                                ("llama3.1:8b",      "Llama 3.1 8B",      "Meta versatile (8GB)"),
+                                // ── Large (12-24GB VRAM) ──
+                                ("qwen2.5:14b",      "Qwen 2.5 14B",      "🌟 High quality Asian (12GB)"),
+                                ("qwen3:14b",        "Qwen 3 14B",        "🆕 Latest Qwen (12GB)"),
+                                ("gemma2:27b",       "Gemma 2 27B",       "Google premium (20GB)"),
+                                ("qwen2.5:32b",      "Qwen 2.5 32B",      "🏆 Premium quality (24GB)"),
+                                ("qwen3:32b",        "Qwen 3 32B",        "🆕 Latest Qwen (24GB)"),
+                                ("aya-expanse:32b",  "Aya Expanse 32B",   "🌐 Best multilingual (24GB)"),
+                                // ── XL (48GB+ VRAM) ──
+                                ("qwen2.5:72b",      "Qwen 2.5 72B",      "🏆 Near GPT-4 (48GB+)"),
+                                ("llama3.3:70b",     "Llama 3.3 70B",     "Meta flagship (48GB+)"),
                             ];
 
                             ui.horizontal(|ui| {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -911,62 +911,52 @@ impl App {
     /// If the response has no numbers at all (single-line or model ignored
     /// the instruction), fall back to plain line-split.
     fn parse_numbered_lines(raw: &str, ocr_count: usize) -> Vec<String> {
-        // Detect whether the response uses the numbered format.
-        let has_numbers = raw.lines().any(|l| {
-            let t = l.trim();
-            t.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false)
-        });
-
-        if !has_numbers || ocr_count == 0 {
-            // Plain split fallback - but ensure we don't return more lines than requested
-            let lines: Vec<String> = raw.lines().map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect();
-            if lines.len() == ocr_count {
-                return lines;
+        /// Strip leading prefixes that AI models commonly add:
+        /// "1. ", "1) ", "1: ", "- ", "* ", "• ", "n. ", etc.
+        fn strip_prefix(s: &str) -> &str {
+            let t = s.trim();
+            // Try stripping leading digits + punctuation (e.g. "1. ", "12) ", "3: ")
+            let after_digits = t.trim_start_matches(|c: char| c.is_ascii_digit());
+            if after_digits.len() < t.len() {
+                // We stripped some digits — now skip punctuation and whitespace
+                let after_punct = after_digits.trim_start_matches(|c: char| {
+                    c == '.' || c == ')' || c == ':' || c == '-' || c == '>' || c.is_whitespace()
+                });
+                if !after_punct.is_empty() {
+                    return after_punct;
+                }
             }
-            // If line count doesn't match, try to use the numbers anyway or fallback to empty
-            let mut res = vec!["ไม่มีข้อความที่ต้องแปล".to_string(); ocr_count];
-            for (idx, line) in lines.iter().enumerate().take(ocr_count) {
-                res[idx] = line.clone();
+            // Try stripping common bullet prefixes
+            for prefix in &["- ", "* ", "• ", "· ", "> "] {
+                if let Some(rest) = t.strip_prefix(prefix) {
+                    return rest.trim();
+                }
             }
-            return res;
+            t
         }
 
-        let mut result = vec!["ไม่มีข้อความที่ต้องแปล".to_string(); ocr_count];
-        for line in raw.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
+        if ocr_count == 0 {
+            return vec![];
+        }
 
-            // Find the first sequence of digits at the start of the line
-            let mut num_str = String::new();
-            for c in trimmed.chars() {
-                if c.is_ascii_digit() {
-                    num_str.push(c);
-                } else {
-                    break;
-                }
-            }
+        // Collect non-empty lines and strip prefixes
+        let cleaned: Vec<String> = raw
+            .lines()
+            .map(|l| strip_prefix(l).to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
 
-            if !num_str.is_empty() {
-                if let Ok(idx) = num_str.parse::<usize>() {
-                    if idx >= 1 && idx <= ocr_count {
-                        // Find where the actual text starts (skip the number and any punctuation like . : ) )
-                        let mut start_idx = num_str.len();
-                        let remaining = &trimmed[start_idx..];
-                        for c in remaining.chars() {
-                            if c == '.' || c == ')' || c == ':' || c.is_whitespace() {
-                                start_idx += c.len_utf8();
-                            } else {
-                                break;
-                            }
-                        }
-                        let content = trimmed[start_idx..].trim().to_string();
-                        if !content.is_empty() {
-                            result[idx - 1] = content;
-                        }
-                    }
-                }
+        if cleaned.len() == ocr_count {
+            return cleaned;
+        }
+
+        // Line count mismatch — pad or truncate
+        let mut result = Vec::with_capacity(ocr_count);
+        for i in 0..ocr_count {
+            if i < cleaned.len() {
+                result.push(cleaned[i].clone());
+            } else {
+                result.push(String::new());
             }
         }
         result

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -719,24 +719,23 @@ impl App {
                                             )
                                         });
 
-                                        // Align translated text to the left edge of the OCR line
-                                        let text_pos = egui::pos2(ocr_line.x, ocr_line.y);
-                                        let text_size = galley.size();
-
-                                        // Dark rounded background only behind this line
-                                        let pad = egui::vec2(5.0, 3.0);
+                                        // Background covers the ENTIRE OCR line area to fully hide original text
+                                        let bg_w = ocr_line.w.max(galley.size().x + 10.0);
+                                        let bg_h = ocr_line.h.max(galley.size().y + 4.0);
                                         let bg = egui::Rect::from_min_size(
-                                            text_pos - pad,
-                                            text_size + pad * 2.0,
+                                            egui::pos2(ocr_line.x - 2.0, ocr_line.y - 1.0),
+                                            egui::vec2(bg_w + 4.0, bg_h + 2.0),
                                         );
+                                        // Fully opaque dark background — NOT pure black (color-keyed)
                                         painter.rect_filled(
                                             bg,
-                                            4.0,
-                                            // NOT from_black_alpha — pure RGB(0,0,0) gets
-                                            // color-keyed to transparent by Win32 LWA_COLORKEY.
-                                            // Use dark navy (non-zero RGB) instead.
-                                            egui::Color32::from_rgba_unmultiplied(18, 18, 30, 220),
+                                            3.0,
+                                            egui::Color32::from_rgba_unmultiplied(18, 18, 30, 255),
                                         );
+
+                                        // Center text vertically within the OCR line box
+                                        let text_y = ocr_line.y + (bg_h - galley.size().y) / 2.0;
+                                        let text_pos = egui::pos2(ocr_line.x, text_y);
                                         painter.galley(text_pos, galley, egui::Color32::WHITE);
                                     }
 
@@ -758,7 +757,7 @@ impl App {
                                                 pos - egui::vec2(5.0, 3.0),
                                                 galley.size() + egui::vec2(10.0, 6.0),
                                             );
-                                            painter.rect_filled(bg, 4.0, egui::Color32::from_rgba_unmultiplied(18, 18, 30, 220));
+                                            painter.rect_filled(bg, 3.0, egui::Color32::from_rgba_unmultiplied(18, 18, 30, 255));
                                             let line_h = galley.size().y;
                                             painter.galley(pos, galley, egui::Color32::WHITE);
                                             y += line_h + 4.0;
@@ -784,7 +783,7 @@ impl App {
                                             pos - egui::vec2(5.0, 3.0),
                                             galley.size() + egui::vec2(10.0, 6.0),
                                         );
-                                        painter.rect_filled(bg, 4.0, egui::Color32::from_rgba_unmultiplied(18, 18, 30, 220));
+                                        painter.rect_filled(bg, 3.0, egui::Color32::from_rgba_unmultiplied(18, 18, 30, 255));
                                         let line_h = galley.size().y;
                                         painter.galley(pos, galley, egui::Color32::WHITE);
                                         y += line_h + 4.0;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -701,6 +701,9 @@ impl App {
                                 let has_positions = !ocr_lines.is_empty();
 
                                 if has_positions {
+                                    // Max width for text wrapping = region width
+                                    let max_text_w = full_rect.width() - 8.0;
+
                                     for (idx, ocr_line) in ocr_lines.iter().enumerate() {
                                         let trans = trans_lines
                                             .get(idx)
@@ -711,16 +714,19 @@ impl App {
                                         // Font size ~90% of OCR line height, clamped sensibly
                                         let font_size = (ocr_line.h * 0.90).clamp(11.0, 26.0);
 
+                                        // Wrap text within region width
+                                        let wrap_width = (max_text_w - ocr_line.x + full_rect.left()).max(100.0);
                                         let galley = ctx.fonts(|f| {
-                                            f.layout_no_wrap(
+                                            f.layout(
                                                 trans.to_string(),
                                                 egui::FontId::proportional(font_size),
                                                 egui::Color32::WHITE,
+                                                wrap_width,
                                             )
                                         });
 
                                         // Background covers the ENTIRE OCR line area to fully hide original text
-                                        let bg_w = ocr_line.w.max(galley.size().x + 10.0);
+                                        let bg_w = ocr_line.w.max(galley.size().x + 10.0).min(wrap_width + 10.0);
                                         let bg_h = ocr_line.h.max(galley.size().y + 4.0);
                                         let bg = egui::Rect::from_min_size(
                                             egui::pos2(ocr_line.x - 2.0, ocr_line.y - 1.0),
@@ -745,11 +751,13 @@ impl App {
                                         let mut y = last.y + last.h + 4.0;
                                         for extra in &trans_lines[ocr_lines.len()..] {
                                             if extra.trim().is_empty() { continue; }
+                                            let wrap_width = (full_rect.width() - last.x + full_rect.left() - 8.0).max(100.0);
                                             let galley = ctx.fonts(|f| {
-                                                f.layout_no_wrap(
+                                                f.layout(
                                                     extra.clone(),
                                                     egui::FontId::proportional(14.0),
                                                     egui::Color32::WHITE,
+                                                    wrap_width,
                                                 )
                                             });
                                             let pos = egui::pos2(last.x, y);
@@ -769,11 +777,13 @@ impl App {
                                     let mut y = full_rect.top() + 8.0;
                                     for line in fallback_text.lines() {
                                         if line.trim().is_empty() { continue; }
+                                        let wrap_width = full_rect.width() - 16.0;
                                         let galley = ctx.fonts(|f| {
-                                            f.layout_no_wrap(
+                                            f.layout(
                                                 line.to_string(),
                                                 egui::FontId::proportional(font_size),
                                                 egui::Color32::WHITE,
+                                                wrap_width,
                                             )
                                         });
                                         let x = (full_rect.center().x - galley.size().x / 2.0)


### PR DESCRIPTION
- Main positional lines now wrap within region width
- Extra translated lines now wrap within region width
- Fallback/Cache-hit lines now wrap within region width

This prevents long translations (especially Thai) from overflowing the
screen or region boundaries.