### PR TITLE
feat: centralize translation prompts with ||| separator protocol for reliable line-aligned batch translation

### DIFF
--- a/src/adapters/translate/gemini.rs
+++ b/src/adapters/translate/gemini.rs
@@ -2,7 +2,11 @@ use anyhow::{bail, Context, Result};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{ports::Translator, types::LanguageTag};
+use crate::core::{
+    ports::Translator,
+    prompt_builder,
+    types::LanguageTag,
+};
 
 #[derive(Debug, Clone)]
 pub struct GeminiModel {
@@ -94,52 +98,15 @@ impl Translator for GeminiTranslator {
             bail!("Gemini API key is empty (open Settings and set it)");
         }
 
-        let source_lines: Vec<&str> = text.lines().collect();
-        let (prompt_body, multi_line) = if source_lines.len() > 1 {
-            let numbered = source_lines
-                .iter()
-                .enumerate()
-                .map(|(i, l)| format!("{}. {}", i + 1, l))
-                .collect::<Vec<_>>()
-                .join("\n");
-            (numbered, true)
-        } else {
-            (text.to_string(), false)
-        };
+        let lines: Vec<&str> = text.lines().collect();
+        let prompt = prompt_builder::build_translation_prompt(&lines, source, target);
 
-        let line_instruction = if multi_line {
-            "CRITICAL: The input is a numbered list of lines. \
-             You MUST return EXACTLY the same number of lines as provided. \
-             Each output line must start with its corresponding number (N. <translation>). \
-             Output ONLY the translation in the target language. \
-             Do NOT include the original Japanese or English text. Do NOT include explanations. \
-             If the target is Thai, output ONLY Thai. \
-             Maintain 1-to-1 mapping. No extra text."
-                .to_string()
-        } else {
-            "Output ONLY the translated text, no explanations.".to_string()
-        };
-
-        let system_instruction = "You are a professional game localizer. \
-             Translate the following text to sound natural, idiomatic, and human-like in the target language. \
-             Avoid literal, word-for-word translations that sound like a robot. \
-             Use appropriate gaming terminology and casual speech where suitable.";
-
-        let prompt = if let Some(src) = source {
-            format!(
-                "{}\n\nTranslate from {} to {}. {}\n\nInput:\n{}",
-                system_instruction, src.0, target.0, line_instruction, prompt_body
-            )
-        } else {
-            format!(
-                "{}\n\nTranslate to {}. Auto-detect the source language. {}\n\nInput:\n{}",
-                system_instruction, target.0, line_instruction, prompt_body
-            )
-        };
+        // Gemini uses a single text prompt combining system + user instructions
+        let combined_prompt = format!("{}\n\n{}", prompt.system, prompt.user);
 
         let body = RequestBody {
             contents: vec![Content {
-                parts: vec![Part { text: prompt }],
+                parts: vec![Part { text: combined_prompt }],
             }],
             generation_config: Some(GenerationConfig {
                 temperature: Some(0.1), // Lower for more deterministic line-by-line output

--- a/src/adapters/translate/groq.rs
+++ b/src/adapters/translate/groq.rs
@@ -2,7 +2,11 @@ use anyhow::{bail, Context, Result};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{ports::Translator, types::LanguageTag};
+use crate::core::{
+    ports::Translator,
+    prompt_builder,
+    types::LanguageTag,
+};
 
 #[derive(Clone)]
 pub struct GroqTranslator {
@@ -38,80 +42,19 @@ impl Translator for GroqTranslator {
             bail!("Groq API key is empty (obtain it from console.groq.com)");
         }
 
-        let source_lines: Vec<&str> = text.lines().collect();
-        let (prompt_body, multi_line) = if source_lines.len() > 1 {
-            let numbered = source_lines
-                .iter()
-                .enumerate()
-                .map(|(i, l)| format!("{}. {}", i + 1, l))
-                .collect::<Vec<_>>()
-                .join("\n");
-            (numbered, true)
-        } else {
-            (text.to_string(), false)
-        };
-
-        // Convert language codes to full names for better AI understanding
-        let target_name = match target.0.as_str() {
-            "th" => "Thai",
-            "en" => "English",
-            "ja" => "Japanese",
-            "zh-Hans" => "Chinese Simplified",
-            "zh-Hant" => "Chinese Traditional",
-            "ko" => "Korean",
-            "vi" => "Vietnamese",
-            "id" => "Indonesian",
-            "ru" => "Russian",
-            "es" => "Spanish",
-            "fr" => "French",
-            "de" => "German",
-            _ => &target.0,
-        };
-
-        let system_prompt = if multi_line {
-            format!(
-                "You are a professional manga/game translator. CRITICAL: Translate each numbered line into {}. \
-                 You MUST return EXACTLY the same number of lines as provided. \
-                 Each output line must start with its corresponding number (N. <translation>). \
-                 Output ONLY the translation in the target language. \
-                 Do NOT include the original Japanese or English text. Do NOT include explanations. \
-                 If the target is Thai, output ONLY Thai. \
-                 Maintain 1-to-1 mapping. No extra text.",
-                target_name
-            )
-        } else {
-            format!(
-                "You are a professional translator. Translate this text into {}. \
-                 Output ONLY the translated text, no explanations.",
-                target_name
-            )
-        };
-
-        let user_prompt = if let Some(src) = source {
-            let src_name = match src.0.as_str() {
-                "th" => "Thai",
-                "en" => "English",
-                "ja" => "Japanese",
-                "zh-Hans" => "Chinese Simplified",
-                "zh-Hant" => "Chinese Traditional",
-                "ko" => "Korean",
-                _ => &src.0,
-            };
-            format!("Translate from {} to {}:\n\n{}", src_name, target_name, prompt_body)
-        } else {
-            format!("Translate to {}:\n\n{}", target_name, prompt_body)
-        };
+        let lines: Vec<&str> = text.lines().collect();
+        let prompt = prompt_builder::build_translation_prompt(&lines, source, target);
 
         let req = GroqChatRequest {
             model: self.model.clone(),
             messages: vec![
                 GroqMessage {
                     role: "system".to_string(),
-                    content: system_prompt.to_string(),
+                    content: prompt.system,
                 },
                 GroqMessage {
                     role: "user".to_string(),
-                    content: user_prompt.to_string(),
+                    content: prompt.user,
                 },
             ],
             temperature: 0.2,

--- a/src/adapters/translate/ollama.rs
+++ b/src/adapters/translate/ollama.rs
@@ -2,7 +2,11 @@ use anyhow::{bail, Context, Result};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{ports::Translator, types::LanguageTag};
+use crate::core::{
+    ports::Translator,
+    prompt_builder,
+    types::LanguageTag,
+};
 
 #[derive(Clone)]
 pub struct OllamaTranslator {
@@ -34,72 +38,10 @@ impl Translator for OllamaTranslator {
         source: Option<&LanguageTag>,
         target: &LanguageTag,
     ) -> Result<String> {
-        let source_lines: Vec<&str> = text.lines().collect();
+        let lines: Vec<&str> = text.lines().collect();
+        let prompt = prompt_builder::build_translation_prompt(&lines, source, target);
 
-        // Convert language codes to full names for better AI understanding
-        let target_name = match target.0.as_str() {
-            "th" => "Thai",
-            "en" => "English",
-            "ja" => "Japanese",
-            "zh-Hans" => "Chinese Simplified",
-            "zh-Hant" => "Chinese Traditional",
-            "ko" => "Korean",
-            "vi" => "Vietnamese",
-            "id" => "Indonesian",
-            "ru" => "Russian",
-            "es" => "Spanish",
-            "fr" => "French",
-            "de" => "German",
-            _ => &target.0,
-        };
-
-        let src_name = source.map(|s| match s.0.as_str() {
-            "th" => "Thai",
-            "en" => "English",
-            "ja" => "Japanese",
-            "zh-Hans" => "Chinese Simplified",
-            "zh-Hant" => "Chinese Traditional",
-            "ko" => "Korean",
-            _ => &s.0,
-        });
-
-        let (prompt_body, multi_line) = if source_lines.len() > 1 {
-            let numbered = source_lines
-                .iter()
-                .enumerate()
-                .map(|(i, l)| format!("{}. {}", i + 1, l))
-                .collect::<Vec<_>>()
-                .join("\n");
-            (numbered, true)
-        } else {
-            (text.to_string(), false)
-        };
-
-        let system = if multi_line {
-            format!(
-                "You are a professional manga/game translator. CRITICAL: Translate each numbered line into {}. \
-                 You MUST return EXACTLY the same number of lines as provided ({} lines). \
-                 Each output line must start with its corresponding number (N. <translation>). \
-                 Output ONLY the translation in the target language. \
-                 Do NOT include the original Japanese or English text. Do NOT include explanations. \
-                 If the target is Thai, output ONLY Thai. \
-                 Maintain 1-to-1 mapping. No extra text.",
-                target_name, source_lines.len()
-            )
-        } else {
-            format!(
-                "Translate to {}. Output ONLY the translated text, no explanations.",
-                target_name
-            )
-        };
-
-        let user = if let Some(sn) = src_name {
-            format!("Translate from {} to {}:\n\n{}", sn, target_name, prompt_body)
-        } else {
-            format!("Translate to {}:\n\n{}", target_name, prompt_body)
-        };
-
-        self.call_ollama(&system, &user)
+        self.call_ollama(&prompt.system, &prompt.user)
     }
 }
 

--- a/src/adapters/translate/openai.rs
+++ b/src/adapters/translate/openai.rs
@@ -2,7 +2,11 @@ use anyhow::{bail, Context, Result};
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 
-use crate::core::{ports::Translator, types::LanguageTag};
+use crate::core::{
+    ports::Translator,
+    prompt_builder,
+    types::LanguageTag,
+};
 
 #[derive(Clone)]
 pub struct OpenAiTranslator {
@@ -43,54 +47,19 @@ impl Translator for OpenAiTranslator {
             bail!("Custom OpenAI Base URL is empty");
         }
 
-        let source_lines: Vec<&str> = text.lines().collect();
-        let (prompt_body, multi_line) = if source_lines.len() > 1 {
-            let numbered = source_lines
-                .iter()
-                .enumerate()
-                .map(|(i, l)| format!("{}. {}", i + 1, l))
-                .collect::<Vec<_>>()
-                .join("\n");
-            (numbered, true)
-        } else {
-            (text.to_string(), false)
-        };
-
-        let system_prompt = if multi_line {
-            format!(
-                "You are an expert manga/game translator. Translate each numbered line to {target_lang}. \
-                Source language: {source_lang}. \
-                Maintain context across lines as they belong to the same scene or speech bubble. \
-                RULES:
-                1. You MUST return EXACTLY the same number of lines.
-                2. Each output line MUST start with its corresponding number (e.g., '1. <translation>').
-                3. Do not add extra commentary, notes, or combine lines.
-                4. Maintain punctuation style appropriate for {target_lang}.",
-                target_lang = target.0,
-                source_lang = source.map(|l| l.0.as_str()).unwrap_or("auto-detect"),
-            )
-        } else {
-            format!(
-                "You are an expert manga/game translator. Translate the text to {target_lang}. \
-                Source language: {source_lang}. \
-                RULES:
-                1. Provide ONLY the translation.
-                2. Do not add any commentary, notes, or quotes.",
-                target_lang = target.0,
-                source_lang = source.map(|l| l.0.as_str()).unwrap_or("auto-detect"),
-            )
-        };
+        let lines: Vec<&str> = text.lines().collect();
+        let prompt = prompt_builder::build_translation_prompt(&lines, source, target);
 
         let req_body = OpenAiRequest {
             model: self.model.clone(),
             messages: vec![
                 OpenAiMessage {
                     role: "system".to_string(),
-                    content: system_prompt,
+                    content: prompt.system,
                 },
                 OpenAiMessage {
                     role: "user".to_string(),
-                    content: prompt_body,
+                    content: prompt.user,
                 },
             ],
             temperature: 0.3,

--- a/src/core/coordinator.rs
+++ b/src/core/coordinator.rs
@@ -420,46 +420,15 @@ impl BackgroundCoordinator {
         }
     }
 
-    /// Parse a numbered translation response back into a Vec aligned to
-    /// the original OCR lines.
+    /// Parse a translation response back into a Vec aligned to the original
+    /// OCR lines. Delegates to the centralized multi-strategy parser in
+    /// `prompt_builder` and applies TextCleaner post-processing.
     fn parse_numbered_lines(raw: &str, ocr_count: usize) -> Vec<String> {
-        if ocr_count == 0 {
-            return vec![];
-        }
-
-        let mut result = vec![String::new(); ocr_count];
-        // Stricter regex to ensure we don't accidentally include the number in the content
-        let re_numbered = regex::Regex::new(r"^\s*(\d+)[\.\):\->\s]+(.*)$").unwrap();
-
-        for line in raw.lines() {
-            let line = line.trim();
-            if line.is_empty() { continue; }
-
-            if let Some(caps) = re_numbered.captures(line) {
-                if let Ok(num) = caps[1].parse::<usize>() {
-                    if num > 0 && num <= ocr_count {
-                        let mut content = caps[2].trim().to_string();
-                        // Strip leading junk that AI sometimes adds
-                        content = content.trim_start_matches(|c: char| c.is_ascii_digit() || c == '.' || c == ' ' || c == '-').trim().to_string();
-                        
-                        if result[num - 1].is_empty() || result[num - 1].len() < content.len() {
-                            result[num - 1] = content;
-                        }
-                    }
-                }
-            } else {
-                for i in 0..ocr_count {
-                    if result[i].is_empty() {
-                        result[i] = line.to_string();
-                        break;
-                    }
-                }
-            }
-        }
-
+        let mut result = crate::core::prompt_builder::parse_translation_response(raw, ocr_count);
         for s in result.iter_mut() {
             *s = TextCleaner::clean(s);
         }
         result
     }
 }
+

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,3 +4,4 @@ pub mod ports;
 pub mod types;
 pub mod text_cleaner;
 pub mod coordinator;
+pub mod prompt_builder;

--- a/src/core/prompt_builder.rs
+++ b/src/core/prompt_builder.rs
@@ -1,0 +1,266 @@
+use crate::core::types::LanguageTag;
+
+// ---------------------------------------------------------------------------
+// Shared language code → human-readable name mapping
+// ---------------------------------------------------------------------------
+
+/// Convert a BCP-47-ish language tag to a human-readable name for AI prompts.
+pub fn lang_name(tag: &LanguageTag) -> &str {
+    match tag.0.as_str() {
+        "th" => "Thai",
+        "en" => "English",
+        "ja" => "Japanese",
+        "zh-Hans" => "Chinese Simplified",
+        "zh-Hant" => "Chinese Traditional",
+        "ko" => "Korean",
+        "vi" => "Vietnamese",
+        "id" => "Indonesian",
+        "ru" => "Russian",
+        "es" => "Spanish",
+        "fr" => "French",
+        "de" => "German",
+        "pt" => "Portuguese",
+        "it" => "Italian",
+        "ar" => "Arabic",
+        "hi" => "Hindi",
+        other => other,
+    }
+}
+
+/// Convert an optional source language tag to a name, defaulting to "auto-detect".
+pub fn lang_name_or_auto(tag: Option<&LanguageTag>) -> &str {
+    match tag {
+        Some(t) => lang_name(t),
+        None => "auto-detect",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Structured prompt builder for line-aligned batch translation
+// ---------------------------------------------------------------------------
+
+/// The separator used between lines in the batch translation protocol.
+/// Three pipe characters are extremely rare in natural text, making them
+/// a reliable delimiter that AI models can reproduce accurately.
+pub const LINE_SEPARATOR: &str = "|||";
+
+/// A ready-to-send prompt pair (system + user message).
+pub struct TranslationPrompt {
+    pub system: String,
+    pub user: String,
+    /// Number of input lines. 0 means single-line mode (no separator protocol).
+    #[allow(dead_code)] // kept for future validation use by callers
+    pub line_count: usize,
+}
+
+/// Build a translation prompt from OCR text lines.
+///
+/// - **Single line:** Simple "translate to X" prompt.
+/// - **Multi-line:** Uses the `|||` separator protocol for reliable line alignment.
+pub fn build_translation_prompt(
+    lines: &[&str],
+    source: Option<&LanguageTag>,
+    target: &LanguageTag,
+) -> TranslationPrompt {
+    let target_name = lang_name(target);
+    let source_name = lang_name_or_auto(source);
+
+    if lines.len() <= 1 {
+        // ── Single-line mode ─────────────────────────────────────────────
+        let system = format!(
+            "You are a professional manga/game translator. \
+             Translate the text to {target_name}. \
+             Output ONLY the translated text, no explanations, no quotes."
+        );
+        let user = if source.is_some() {
+            format!("Translate from {source_name} to {target_name}:\n\n{}", lines.first().unwrap_or(&""))
+        } else {
+            format!("Translate to {target_name}:\n\n{}", lines.first().unwrap_or(&""))
+        };
+        TranslationPrompt { system, user, line_count: lines.len() }
+    } else {
+        // ── Multi-line batch mode (||| separator protocol) ───────────────
+        let joined_input = lines.join(&format!(" {LINE_SEPARATOR} "));
+
+        let system = format!(
+            "You are an expert manga/game translator.\n\
+             The input contains {count} text segments separated by \"{sep}\".\n\
+             Translate EACH segment to {target_name} and output the translations separated by \"{sep}\".\n\
+             \n\
+             CRITICAL RULES:\n\
+             - Output EXACTLY {count} segments, separated by \"{sep}\".\n\
+             - Do NOT add line numbers, bullet points, or explanations.\n\
+             - Do NOT merge or split segments.\n\
+             - If a segment is empty or untranslatable, output it unchanged.\n\
+             - Maintain context across segments (they belong to the same scene).\n\
+             - Output ONLY in {target_name}.",
+            count = lines.len(),
+            sep = LINE_SEPARATOR,
+            target_name = target_name,
+        );
+
+        let user = if source.is_some() {
+            format!("Translate from {source_name} to {target_name}:\n\n{joined_input}")
+        } else {
+            format!("Translate to {target_name}:\n\n{joined_input}")
+        };
+
+        TranslationPrompt { system, user, line_count: lines.len() }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Response parser — multi-strategy alignment
+// ---------------------------------------------------------------------------
+
+/// Parse a translation response back into individual lines, aligned to the
+/// expected OCR line count. Uses multiple fallback strategies:
+///
+/// 1. `|||` separator (preferred — matches our prompt protocol)
+/// 2. Numbered list (`1. text`, `1) text`, `1: text`, `[1] text`)
+/// 3. Plain newline split
+/// 4. Best-effort pad/truncate
+pub fn parse_translation_response(raw: &str, expected_count: usize) -> Vec<String> {
+    if expected_count == 0 {
+        return vec![];
+    }
+
+    let trimmed = raw.trim();
+
+    // ── Strategy 1: ||| separator ────────────────────────────────────────
+    if trimmed.contains(LINE_SEPARATOR) {
+        let parts: Vec<String> = trimmed
+            .split(LINE_SEPARATOR)
+            .map(|s| s.trim().to_string())
+            .collect();
+        if parts.len() == expected_count {
+            return parts;
+        }
+        // If close enough (off by 1-2), try to align
+        if parts.len() >= expected_count {
+            return parts[..expected_count].to_vec();
+        }
+    }
+
+    // ── Strategy 2: Numbered list ────────────────────────────────────────
+    let re_numbered = regex::Regex::new(r"^\s*\[?\s*(\d+)\s*\]?\s*[\.)\:\->\s]+\s*(.*)$").unwrap();
+    let mut numbered_result = vec![String::new(); expected_count];
+    let mut matched_any = false;
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if line.is_empty() { continue; }
+        if let Some(caps) = re_numbered.captures(line) {
+            if let Ok(num) = caps[1].parse::<usize>() {
+                if num > 0 && num <= expected_count {
+                    let content = caps[2].trim().to_string();
+                    if numbered_result[num - 1].is_empty() || numbered_result[num - 1].len() < content.len() {
+                        numbered_result[num - 1] = content;
+                        matched_any = true;
+                    }
+                }
+            }
+        }
+    }
+
+    // Accept numbered result if we matched at least half the expected lines
+    if matched_any {
+        let filled = numbered_result.iter().filter(|s| !s.is_empty()).count();
+        if filled >= (expected_count + 1) / 2 {
+            return numbered_result;
+        }
+    }
+
+    // ── Strategy 3: Plain newline split ──────────────────────────────────
+    let lines: Vec<String> = trimmed
+        .lines()
+        .map(|l| l.trim().to_string())
+        .filter(|l| !l.is_empty())
+        .collect();
+
+    if lines.len() == expected_count {
+        return lines;
+    }
+
+    // ── Strategy 4: Best-effort pad/truncate ─────────────────────────────
+    let mut result = if lines.len() > expected_count {
+        lines[..expected_count].to_vec()
+    } else {
+        lines
+    };
+
+    // Pad with empty strings to reach expected count
+    while result.len() < expected_count {
+        result.push(String::new());
+    }
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lang_name() {
+        assert_eq!(lang_name(&LanguageTag("th".to_string())), "Thai");
+        assert_eq!(lang_name(&LanguageTag("ja".to_string())), "Japanese");
+        assert_eq!(lang_name(&LanguageTag("unknown".to_string())), "unknown");
+    }
+
+    #[test]
+    fn test_parse_separator() {
+        let raw = "สวัสดี ||| สบายดีไหม ||| ขอบคุณ";
+        let result = parse_translation_response(raw, 3);
+        assert_eq!(result, vec!["สวัสดี", "สบายดีไหม", "ขอบคุณ"]);
+    }
+
+    #[test]
+    fn test_parse_numbered() {
+        let raw = "1. สวัสดี\n2. สบายดีไหม\n3. ขอบคุณ";
+        let result = parse_translation_response(raw, 3);
+        assert_eq!(result, vec!["สวัสดี", "สบายดีไหม", "ขอบคุณ"]);
+    }
+
+    #[test]
+    fn test_parse_newline_fallback() {
+        let raw = "Hello\nWorld\nFoo";
+        let result = parse_translation_response(raw, 3);
+        assert_eq!(result, vec!["Hello", "World", "Foo"]);
+    }
+
+    #[test]
+    fn test_parse_pad_short() {
+        let raw = "Hello\nWorld";
+        let result = parse_translation_response(raw, 4);
+        assert_eq!(result, vec!["Hello", "World", "", ""]);
+    }
+
+    #[test]
+    fn test_parse_truncate_long() {
+        let raw = "A\nB\nC\nD\nE";
+        let result = parse_translation_response(raw, 3);
+        assert_eq!(result, vec!["A", "B", "C"]);
+    }
+
+    #[test]
+    fn test_single_line_prompt() {
+        let target = LanguageTag("th".to_string());
+        let prompt = build_translation_prompt(&["Hello"], None, &target);
+        assert_eq!(prompt.line_count, 1);
+        assert!(!prompt.system.contains("|||"));
+    }
+
+    #[test]
+    fn test_multi_line_prompt() {
+        let target = LanguageTag("th".to_string());
+        let prompt = build_translation_prompt(&["Hello", "World"], None, &target);
+        assert_eq!(prompt.line_count, 2);
+        assert!(prompt.system.contains("|||"));
+        assert!(prompt.user.contains("|||"));
+    }
+}


### PR DESCRIPTION
- Add core/prompt_builder.rs: shared prompt builder with ||| separator protocol, unified lang_name mapping, and multi-strategy response parser (||| → numbered list → newline → best-effort pad/truncate)
- Refactor all 4 translation adapters (Gemini, Groq, Ollama, OpenAI) to use the shared prompt_builder instead of duplicated prompt logic
- Simplify coordinator::parse_numbered_lines to delegate to the new centralized parse_translation_response with TextCleaner post-processing
- Add 8 unit tests covering separator parsing, numbered list fallback, newline fallback, pad/truncate edge cases, and prompt generation